### PR TITLE
fix(types): resolve lua-language-server type check failures

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Type Check
-        uses: mrcjkb/lua-typecheck-action@v0
+        uses: mrcjkb/lua-typecheck-action@v1
         with:
           directories: lua
           configpath: .luarc.json

--- a/lua/beam/config.lua
+++ b/lua/beam/config.lua
@@ -19,6 +19,7 @@ local M = {}
 
 ---@class BeamConfig
 ---@field prefix string Prefix for all mappings
+---@field backward_prefix string|nil Optional prefix for backward search mappings
 ---@field visual_feedback_duration number Duration of visual feedback in milliseconds
 ---@field clear_highlight boolean Clear search highlight after operation
 ---@field clear_highlight_delay number Delay before clearing highlight in milliseconds

--- a/lua/beam/mappings.lua
+++ b/lua/beam/mappings.lua
@@ -24,7 +24,7 @@ end
 ---@param op_key string Operator key
 ---@param op_info table Operator info
 ---@param search_char string Search character ('/' or '?')
----@param direction_suffix string Suffix for description ('forward' or 'backward')
+---@param direction_suffix? string Suffix for description ('forward' or 'backward')
 local function setup_text_object_mappings(prefix, op_key, op_info, search_char, direction_suffix)
   search_char = search_char or '/'
   direction_suffix = direction_suffix or ''
@@ -50,7 +50,7 @@ end
 ---@param op_key string Operator key
 ---@param op_info table Operator info
 ---@param search_char string Search character ('/' or '?')
----@param direction_suffix string Suffix for description
+---@param direction_suffix? string Suffix for description
 local function setup_motion_mappings(prefix, op_key, op_info, search_char, direction_suffix)
   search_char = search_char or '/'
   direction_suffix = direction_suffix or ''
@@ -66,7 +66,7 @@ end
 ---Setup line operator mappings
 ---@param prefix string Prefix for mappings
 ---@param search_char string Search character ('/' or '?')
----@param direction_suffix string Suffix for description
+---@param direction_suffix? string Suffix for description
 local function setup_line_operators(prefix, search_char, direction_suffix)
   search_char = search_char or '/'
   direction_suffix = direction_suffix or ''


### PR DESCRIPTION
## Summary
- Add missing `backward_prefix` field to `BeamConfig` class annotation
- Mark `direction_suffix` params as optional (`?`) in 3 mapping functions
- Bump `mrcjkb/lua-typecheck-action` v0 → v1

## Test plan
- [x] Unit tests pass locally (plenary)
- [x] CI type check workflow passes